### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_product, only: [:show, :edit, :update]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_product, only: [:show, :edit, :update, :destroy]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   def index
     @products = Product.all.order(created_at: :desc)
@@ -31,6 +31,14 @@ class ProductsController < ApplicationController
       redirect_to @product
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @product.destroy
+      redirect_to root_path
+    else
+      redirect_to @product
     end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -35,11 +35,8 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    if @product.destroy
-      redirect_to root_path
-    else
-      redirect_to @product
-    end
+    @product.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user == @product.user %>
           <%= link_to "商品の編集", edit_product_path(@product) , method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+          <%= link_to "削除", product_path(@product), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "products#index"
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products
 end


### PR DESCRIPTION
# What
商品削除機能を実装した。

# Why
商品情報を削除するため。


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/72904db22b97600850b2c55355a7d96e

宜しくお願い致します！